### PR TITLE
auth_token post requires client id & secret

### DIFF
--- a/spring-social-yammer/src/main/java/org/springframework/social/yammer/api/connect/YammerOAuth2Template.java
+++ b/spring-social-yammer/src/main/java/org/springframework/social/yammer/api/connect/YammerOAuth2Template.java
@@ -25,6 +25,8 @@ public class YammerOAuth2Template extends OAuth2Template {
 
 	public YammerOAuth2Template(String clientId, String clientSecret) {
 		super(clientId, clientSecret, "https://www.yammer.com/dialog/oauth", "https://www.yammer.com/oauth2/access_token");
+		//Yammer requires client_id and client_secret as part of access_token POST
+		setUseParametersForClientAuthentication(true);
 	}
 	
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Calling setUseParametersForClientAuthentication in the constructor.
## As per Yammer authentication documentation: 

C. App Authentication

Next, submit a POST request on the OAuth 2.0 Token Endpoint, passing in the authorization code (you received above), client_id and client_secret (found on app configuration page), in the request body. The endpoint is:

Text
POST https://www.yammer.com/oauth2/access_token
## client_id=[:client_id]&client_secret=[:client_secret]&code=[:code]&grant_type=authorization_code

By calling above set method, spring social security is passing required parameters!
